### PR TITLE
Make filtering thresholds configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ This repository contains a GPU-accelerated Snakemake workflow that calls both va
    - `split_n`: number of independent jobs of `gatk` for parallelism
    - `memory_gb_per_interval`: memory in Gb for each independent `gatk` job
 
+## Filtering parameters
+The following configuration options adjust variant filtering in `rules/4.vcf_filtering.smk`:
+
+- `gq_min`: minimum genotype quality to keep a call (default `20`).
+- `qual_min`: minimum site QUAL score (default `30`).
+- `dp_max`: maximum average depth across samples (default `50`).
+- `f_missing_max`: maximum allowed fraction of missing genotypes (default `0.5`).
+
 ## Usage:
 `snakemake --use-conda --use-singularity --singularity-args '--nv -B .:/dum' --cores [ncpu] --resources gpus=[ngpu] mem_gb=[mem]`
 

--- a/configuration/config.yaml
+++ b/configuration/config.yaml
@@ -16,3 +16,9 @@ w_size: 100000
 split_n: 100
 ### memory limit for EACH interval (Gb)
 memory_gb_per_interval: 1
+
+## Filtering parameters
+gq_min: 20
+qual_min: 30
+dp_max: 50
+f_missing_max: 0.5

--- a/rules/4.vcf_filtering.smk
+++ b/rules/4.vcf_filtering.smk
@@ -102,14 +102,14 @@ rule getHQSNPs:
     shell:
         """
             bcftools filter \
-                -S . -e 'FMT/GQ<20' \
+                -S . -e 'FMT/GQ<{config[gq_min]}' \
                 {input} | \
             bcftools filter \
                 -s 'FAIL' \
-                -e 'QUAL<30 || N_ALLELES>2 || AVG(FMT/DP)>50 || TYPE!="snp" || F_MISSING>0.5' | \
+                -e 'QUAL<{config[qual_min]} || N_ALLELES>2 || AVG(FMT/DP)>{config[dp_max]} || TYPE!="snp" || F_MISSING>{config[f_missing_max]}' | \
             bcftools view \
                 -f 'PASS' \
-                -Oz -o {output} 
+                -Oz -o {output}
         """
 
 rule mergeRefCallsAndHQSNPs:


### PR DESCRIPTION
## Summary
- Add filtering threshold options (gq_min, qual_min, dp_max, f_missing_max) to configuration
- Use new configuration in HQ SNP filtering rule
- Document filtering parameters in README

## Testing
- `snakemake --lint` *(fails: command not found)*
- `pip install snakemake` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895e4f69b80832b90301f3b6fc3980f