### PR TITLE
Exclude alternate alleles from reference call step

### DIFF
--- a/rules/4.vcf_filtering.smk
+++ b/rules/4.vcf_filtering.smk
@@ -84,7 +84,7 @@ rule getRefCalls:
     shell:
         """
             bcftools view \
-                --max-ac=1 \
+                --max-ac=0 \
                 {input} \
                 -Oz -o {output}
         """


### PR DESCRIPTION
## Summary
- Use `--max-ac=0` when extracting reference calls to drop any sites carrying alternate alleles

## Testing
- `bcftools --version` *(fails: command not found)*
- `gatk --version` *(fails: command not found)*
- `snakemake --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895eb297f9c832b878dc4b91da58bc0