### PR TITLE
Use wildcards.sample in get_fastq helper

### DIFF
--- a/rules/utils.smk
+++ b/rules/utils.smk
@@ -1,5 +1,5 @@
 def get_fastq(wildcards):
-    fastqs = sample_sheet.loc[(wildcards), ["r1", "r2"]].dropna()
+    fastqs = sample_sheet.loc[wildcards.sample, ["r1", "r2"]].dropna()
     return {"r1": fastqs.r1, "r2": fastqs.r2}
 
 def get_fastq2(wildcards):


### PR DESCRIPTION
## Summary
- reference `wildcards.sample` when selecting fastqs
- verified other utils helpers already use `wildcards.sample`

## Testing
- `snakemake --lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895ecb13c2c832b98e170d186f65ae5